### PR TITLE
Add ability to handle headers in the schema specification

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-it/fastify",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "test": "node --test --experimental-transform-types",

--- a/src/index.ts
+++ b/src/index.ts
@@ -234,6 +234,10 @@ const McpPlugin: FastifyPluginAsync<McpPluginOptions> = async (
         routeOptions.schema?.body,
         routeOptions.schema
       ),
+      headers: resolveSchemaReferences(
+        routeOptions.schema?.headers,
+        routeOptions.schema
+      ),
       params: resolveSchemaReferences(
         routeOptions.schema?.params,
         routeOptions.schema

--- a/src/services/request-handler.ts
+++ b/src/services/request-handler.ts
@@ -8,6 +8,7 @@ export function requestHandler(fastify: FastifyInstance) {
     args: Record<string, any>
   ): McpToolPayload {
     const payload: McpToolPayload = {
+      headers: {},
       params: {},
       query: {},
       body: {},
@@ -15,6 +16,10 @@ export function requestHandler(fastify: FastifyInstance) {
 
     // Assign parameters to the appropriate location
     for (const [key, value] of Object.entries(args)) {
+      // Check if this is a header parameter
+      if (route.headers?.properties?.[key]) {
+        payload.headers[key] = value;
+      }
       // Check if this is a path parameter
       if (route.params?.properties?.[key]) {
         payload.params[key] = value;
@@ -68,6 +73,7 @@ export function requestHandler(fastify: FastifyInstance) {
 
     // Execute request using fastify.inject
     const result = await fastify.inject({
+      headers: payload.headers,
       method: route.methods[0],
       url,
       query: payload.query,

--- a/src/services/tool-converter.ts
+++ b/src/services/tool-converter.ts
@@ -44,6 +44,22 @@ export function toolConverter(options: McpPluginOptions) {
     const properties: Record<string, any> = {};
     const required: string[] = [];
 
+    // Add header parameters
+    if (route.headers) {
+      for (const [key, schema] of Object.entries(
+        route.headers.properties || {}
+      )) {
+        properties[key] = {
+          type: getSchemaType(schema),
+          title: key,
+          description: (schema as any).description ?? `Header: ${key}`,
+        };
+        if ((route.headers.required || []).includes(key)) {
+          required.push(key);
+        }
+      }
+    }
+
     // Add path parameters
     if (route.params) {
       for (const [key, schema] of Object.entries(

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ export interface Route {
   summary?: string;
   description?: string;
   tags?: string[];
+  headers?: any;
   querystring?: any;
   body?: any;
   params?: any;
@@ -89,6 +90,7 @@ export interface McpTool {
 }
 
 export interface McpToolPayload {
+  headers: Record<string, any>;
   params: Record<string, any>;
   query: Record<string, any>;
   body: Record<string, any>;


### PR DESCRIPTION
This is required for API endpoints that have Authorization headers defined in the schema. 

`buildToolInputSchema` now checks the route for `headers` and if present it will add it to the schema
Headers are also added to the payload.

E.g.
```
fastify.get(
        "/hello",
        {
          config: {
            mcp: {
              name: "my_hello",
              description: "The is my hello tool",
            },
          },
          schema: {
            operationId: "hello",
            summary: "Hello World",
            description: "Says hello",
            headers: {
              type: "object",
              properties: {
                authorization: {
                  type: "string",
                  description: "Authorization header as a bearer token",
                },
              },
              required: ["authorization"],
            }
          },
        },
        () => "Hello World"
      );
    });
``` 